### PR TITLE
docs: fixes get_check args

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -75,7 +75,7 @@ Getting a Check
 
     client = Client(api_key="myapikey")
 
-    check = client.get_check(uuid="mychecksuuid")
+    check = client.get_check(check_id="mychecksuuid")
     print(check)
 
 Pinging a Check


### PR DESCRIPTION
Hi there,

first of all: what a great little library 😃 

I found a little typo in the docs.

[The docs say](https://py-healthchecksio.readthedocs.io/en/latest/usage.html#getting-a-check):
`client.get_check(uuid="mychecksuuid")`

But the code requires:
https://github.com/andrewthetechie/py-healthchecks.io/blob/321828dfb6e4f464b9fae1623e357578398c937d/src/healthchecks_io/client/sync_client.py#L99